### PR TITLE
Remove Python2 code from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,15 +94,8 @@ As a standalone library
 
     >>> import os
     >>> import sys
-    >>> if sys.version_info[0] < 3:
-    ...     from StringIO import StringIO
-    ... else:
-    ...     from io import BytesIO as StringIO
-    >>> PY2 = sys.version_info[0] == 2
-    >>> if PY2 and sys.version_info[1] < 7:
-    ...      from ordereddict import OrderedDict
-    ... else:
-    ...     from collections import OrderedDict
+    >>> from io import BytesIO as StringIO
+    >>> from collections import OrderedDict
 
 
 .. testcode::


### PR DESCRIPTION
Python2 is not supported anymore per https://github.com/pyexcel/pyexcel-odsr/blob/dev/setup.py#L53

With your PR, here is a check list:

- [ ] Has test cases written? no
- [x] Has all code lines tested?
- [ ] Has `make format` been run? no
- [ ] Please update CHANGELOG.yml(not CHANGELOG.rst) is it really needed
- [ ] Has fair amount of documentation if your change is complex - not applicable
- [x] Agree on NEW BSD License for your contribution
